### PR TITLE
add channel/time to my shows list

### DIFF
--- a/src/com/arantius/tivocommander/MyShows.java
+++ b/src/com/arantius/tivocommander/MyShows.java
@@ -110,8 +110,20 @@ public class MyShows extends ListActivity {
           Date startTime =
               Utils.parseDateTimeStr(item.path("startTime").getTextValue());
           SimpleDateFormat dateFormatter = new SimpleDateFormat("EEE M/d");
-          ((TextView) v.findViewById(R.id.show_time)).setText(dateFormatter
-              .format(startTime));
+          String str = dateFormatter.format(startTime);
+
+          if (folderItemCount == 0) {
+              JsonNode recording = item.path("recordingForChildRecordingId");
+		  if (recording.has("channel")) {
+			  JsonNode channel = recording.path("channel");
+			  String cNum = channel.path("channelNumber").getTextValue();
+			  String callSign = channel.path("callSign").getTextValue();
+			  String time = new SimpleDateFormat("HH:mm").format(startTime);
+			  str = String.format("%s %s  %s %s", cNum, callSign, time, str);
+		  }
+          }
+
+          ((TextView) v.findViewById(R.id.show_time)).setText(str);
         }
 
         int iconId = MyShows.getIconForItem(item);

--- a/src/com/arantius/tivocommander/rpc/request/RecordingFolderItemSearch.java
+++ b/src/com/arantius/tivocommander/rpc/request/RecordingFolderItemSearch.java
@@ -29,7 +29,7 @@ import com.arantius.tivocommander.rpc.MindRpc;
 public class RecordingFolderItemSearch extends MindRpcRequest {
   private static final JsonNode mResponseTemplate =
       Utils
-          .parseJson("[{\"type\":\"responseTemplate\",\"fieldName\":[\"recordingFolderItem\"],\"typeName\":\"recordingFolderItemList\"},{\"type\":\"responseTemplate\",\"fieldName\":[\"folderTransportType\",\"folderType\",\"recordingFolderItemId\",\"recordingForChildRecordingId\",\"folderItemCount\",\"recordingStatusType\",\"startTime\",\"title\",\"childRecordingId\"],\"typeName\":\"recordingFolderItem\"},{\"type\":\"responseTemplate\",\"fieldName\":[\"contentId\",\"collectionId\",\"hdtv\",\"startTime\"],\"typeName\":\"recording\"}]");
+          .parseJson("[{\"type\":\"responseTemplate\",\"fieldName\":[\"recordingFolderItem\"],\"typeName\":\"recordingFolderItemList\"},{\"type\":\"responseTemplate\",\"fieldName\":[\"folderTransportType\",\"folderType\",\"recordingFolderItemId\",\"recordingForChildRecordingId\",\"folderItemCount\",\"recordingStatusType\",\"startTime\",\"title\",\"childRecordingId\"],\"typeName\":\"recordingFolderItem\"},{\"type\":\"responseTemplate\",\"fieldName\":[\"contentId\",\"collectionId\",\"hdtv\",\"channel\",\"startTime\"],\"typeName\":\"recording\"}]");
 
   /** Produces an idSequence of shows for the given folder, all if null. */
   public RecordingFolderItemSearch(String folderId, String orderBy) {


### PR DESCRIPTION
While browsing the My Shows list, I often wonder if a particular recording was recorded from the SD or HD channel, so this patch adds channel and recording time info to the list.
