### PR TITLE
Fix for Disk Used with new 14.9 TiVo software

### DIFF
--- a/src/com/arantius/tivocommander/MyShows.java
+++ b/src/com/arantius/tivocommander/MyShows.java
@@ -200,8 +200,8 @@ public class MyShows extends ListActivity {
           ProgressBar mMeter = (ProgressBar) findViewById(R.id.meter);
           TextView mMeterText = (TextView) findViewById(R.id.meter_text);
           JsonNode bodyConfig = response.getBody().path("bodyConfig").path(0);
-          int used = bodyConfig.path("userDiskUsed").getIntValue();
-          int size = bodyConfig.path("userDiskSize").getIntValue();
+          int used = bodyConfig.path("userDiskUsed").getValueAsInt();
+          int size = bodyConfig.path("userDiskSize").getValueAsInt();
 
           mMeter.setMax(size);
           mMeter.setProgress(used);


### PR DESCRIPTION
I have a Premiere from RCN which was just updated to the 14.9 software; most things work as before, but I noticed that the Disk Usage display in TiVo Commander started reading 0% rather than the real number.  This turns out to be because the userDiskUsed and userDiskSize fields are now Textual rather than numeric.  But the fix is pretty simple.
